### PR TITLE
Enable use of MAUDE with computed quaternion pseudo-MSID

### DIFF
--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -391,7 +391,7 @@ class Comp_Quat(ComputedMsid):
 
     msid_match = r"quat_(aoattqt|aoatupq|aocmdqt|aotarqt)"
 
-    def get_msid_attrs(self, tstart: float, tstop:float, msid: str, msid_args: tuple):
+    def get_msid_attrs(self, tstart: float, tstop: float, msid: str, msid_args: tuple):
         from Quaternion import Quat, normalize
 
         msid_root = msid_args[0]

--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -387,6 +387,12 @@ class Comp_Quat(ComputedMsid):
              [193.28905485,  19.1689407 ,  67.36208471],
              [193.28906329,  19.16893787,  67.36207699],
              [193.28908839,  19.16895134,  67.36206404]])
+
+    This computed MSID can be used with the MAUDE data source. Be aware that if the
+    telemetry has a missing VCDU then there is a risk of getting a slightly incorrect
+    quaternion. This would occur since the code uses nearest-neighbor interpolation to
+    associate the four components of the quaternion with a single time. For back-orbit
+    data this is rare, but for real-time data it is more likely.
     """
 
     msid_match = r"quat_(aoattqt|aoatupq|aocmdqt|aotarqt)"

--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -391,23 +391,27 @@ class Comp_Quat(ComputedMsid):
 
     msid_match = r"quat_(aoattqt|aoatupq|aocmdqt|aotarqt)"
 
-    def get_msid_attrs(self, tstart, tstop, msid, msid_args):
+    def get_msid_attrs(self, tstart: float, tstop:float, msid: str, msid_args: tuple):
         from Quaternion import Quat, normalize
-
-        if "maude" in self.fetch_sys.data_source.sources():
-            raise ValueError(
-                f"{msid} is not available from MAUDE due to issues aligning telemetry"
-            )
 
         msid_root = msid_args[0]
         n_comp = 4 if msid_root == "aoattqt" else 3
         msids = [f"{msid_root}{ii}" for ii in range(1, n_comp + 1)]
-        dat = self.fetch_sys.MSIDset(msids, tstart, tstop)
+
+        # Get the raw MSIDs. Fetch a bit extra to avoid edge effects, in particular a
+        # MAUDE query with a start time that lands between components of a quaternion.
+        # E.g. aocmdqt* are spread over about 0.5 sec, but aoattqt seems to be within
+        # the same minor frame.
+        dat = self.fetch_sys.MSIDset(msids, tstart - 35, tstop + 35)
 
         # Interpolate to a common time base, leaving in flagged bad data and
-        # marking data bad if any of the set at each time are bad. See:
+        # marking data bad if any of the set at each time are bad. Note that this uses
+        # nearest-neighbor interpolation. Empirically for these MSIDs that will work to
+        # correctly bin the components together. See:
         # https://sot.github.io/eng_archive/fetch_tutorial.html#filtering-and-bad-values
-        dat.interpolate(times=dat[msids[0]].times, filter_bad=False, bad_union=True)
+        times = dat[msids[0]].times
+        ok = (times >= tstart) & (times < tstop)
+        dat.interpolate(times=times[ok], filter_bad=False, bad_union=True)
 
         q1 = dat[msids[0]].vals.astype(np.float64)
         q2 = dat[msids[1]].vals.astype(np.float64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+
+[tool.ruff]
+line-length = 100

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,0 @@
-[pytest]
-filterwarnings =
-    # See https://github.com/numpy/numpy/issues/11788 for why this is benign
-    ignore:numpy.ufunc size changed:RuntimeWarning
-    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
-    ignore:parse functions are required to provide a named argument:PendingDeprecationWarning
-    ignore:'soft_unicode' has been renamed to 'soft_str':DeprecationWarning
-    ignore:`np.object` is a deprecated alias for the builtin `object`:DeprecationWarning


### PR DESCRIPTION
## Description

This removes a limitation of the original implementation for the computed quaternion pseudo-MSIDs (https://sot.github.io/cheta/pseudo_msids.html#cheta.derived.comps.Comp_Quat)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (updated unit test)

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
