### PR TITLE
Improve pitch/roll_comp, logical_intervals, state_intervals, get_ofp_states, get_telem_table

### DIFF
--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -564,7 +564,26 @@ class Comp_KadiCommandState(ComputedMsid):
 
 
 @functools.lru_cache(maxsize=1)
-def get_roll_pitch_tlm(start, stop):
+def get_roll_pitch_tlm_safe_table(start, stop):
+    """Get telemetry values to compute pitch and roll in safe mode"""
+    from cheta.utils import get_telem_table
+
+    msids = ["6sares1", "6sares2", "6sunsa1", "6sunsa2", "6sunsa3"]
+    dat = get_telem_table(msids, start, stop)
+
+    # Filter out of range values. This happens just at the beginning of safe mode.
+    bads = np.zeros(len(dat), dtype=bool)
+    for msid in msids:
+        x0, x1 = 0, 180 if ("6sares" in msid) else -1, 1
+        bads |= (dat[msid].vals < x0) | (dat[msid].vals > x1)
+    if np.any(bads):
+        dat = dat[~bads]
+
+    return dat
+
+
+@functools.lru_cache(maxsize=1)
+def get_roll_pitch_tlm_safe(start, stop):
     """Get telemetry values to compute pitch and roll in safe mode"""
     from cheta import fetch
 
@@ -579,7 +598,15 @@ def get_roll_pitch_tlm(start, stop):
             x0, x1 = -1, 1
         dat[msid].bads |= (dat[msid].vals < x0) | (dat[msid].vals > x1)
 
-    dat.interpolate(times=dat[msids[0]].times, bad_union=True)
+    if any(len(dat[msid]) == 0 for msid in msids):
+        dat.times = np.array([], dtype=float)
+        for msid in msids:
+            dat[msid].times = np.array([], dtype=float)
+            dat[msid].vals = np.array([], dtype=float)
+            dat[msid].bads = np.array([], dtype=bool)
+    else:
+        dat.interpolate(times=dat[msids[0]].times, bad_union=True)
+
     return dat
 
 
@@ -587,7 +614,7 @@ def calc_css_pitch_safe(start, stop):
     from .pcad import arccos_clip, calc_sun_vec_body_css
 
     # Get the raw telemetry value in user-requested unit system
-    dat = get_roll_pitch_tlm(start, stop)
+    dat = get_roll_pitch_tlm_safe(start, stop)
 
     sun_vec_norm, bads = calc_sun_vec_body_css(dat, safe_mode=True)
     vals = np.degrees(arccos_clip(sun_vec_norm[0]))
@@ -611,7 +638,7 @@ def calc_css_roll_safe(start, stop):
     from .pcad import calc_sun_vec_body_css
 
     # Get the raw telemetry value in user-requested unit system
-    data = get_roll_pitch_tlm(start, stop)
+    data = get_roll_pitch_tlm_safe(start, stop)
 
     sun_vec_norm, bads = calc_sun_vec_body_css(data, safe_mode=True)
     vals = np.degrees(np.arctan2(-sun_vec_norm[1, :], -sun_vec_norm[2, :]))
@@ -704,6 +731,11 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
         for ofp_state in ofp_states:
             if ofp_state["val"] == "NRML":
                 dat = fetch.Msid("aopcadmd", ofp_state["tstart"], ofp_state["tstop"])
+                if len(dat) == 0:
+                    # For an interval with no samples put in empty arrays so that
+                    # subsequent processing succeeds.
+                    tlms.append((np.array([], dtype=float), np.array([], dtype=float)))
+                    continue
 
                 # Get states of either NPNT / NMAN or NSUN
                 vals = np.isin(dat.vals, ["NPNT", "NMAN"])
@@ -721,10 +753,10 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
 
                 for state in states:
                     if state["val"] == "NPNT_NMAN":
-                        tlm = calc_pitch_roll_obc(
+                        times, vals = calc_pitch_roll_obc(
                             state["tstart"], state["tstop"], pitch_roll
                         )
-                        tlms.append(tlm)
+                        tlms.append((times, vals))
                     elif state["val"] == "NSUN":
                         tlm = fetch.Msid(
                             f"{pitch_roll}_css", state["tstart"], state["tstop"]

--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -585,9 +585,8 @@ def get_roll_pitch_tlm_safe_table(start, stop):
 @functools.lru_cache(maxsize=1)
 def get_roll_pitch_tlm_safe(start, stop):
     """Get telemetry values to compute pitch and roll in safe mode.
-    
-    This uses the OBC-computed sun position in the solar array frame from CSS data.
-    """
+
+    This uses the OBC-computed sun position in the solar array frame from CSS data."""
     from cheta import fetch
 
     msids = ["6sares1", "6sares2", "6sunsa1", "6sunsa2", "6sunsa3"]

--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -584,7 +584,10 @@ def get_roll_pitch_tlm_safe_table(start, stop):
 
 @functools.lru_cache(maxsize=1)
 def get_roll_pitch_tlm_safe(start, stop):
-    """Get telemetry values to compute pitch and roll in safe mode"""
+    """Get telemetry values to compute pitch and roll in safe mode.
+    
+    This uses the OBC-computed sun position in the solar array frame from CSS data.
+    """
     from cheta import fetch
 
     msids = ["6sares1", "6sares2", "6sunsa1", "6sunsa2", "6sunsa3"]

--- a/cheta/tests/test_comps.py
+++ b/cheta/tests/test_comps.py
@@ -2,6 +2,7 @@
 
 """Test that computed MSIDs work as expected."""
 
+import astropy.units as u
 import numpy as np
 import pytest
 from cxotime import CxoTime
@@ -286,6 +287,15 @@ def test_pitch_comp():
     )
     # fmt: on
     assert np.allclose(dat.vals, exp, rtol=0, atol=2e-2)
+
+
+@pytest.mark.parametrize("start", ["2022:200", "2022:295:18:00:00", "2022:295"])
+@pytest.mark.parametrize("pitch_roll", ["pitch", "roll"])
+def test_pitch_roll_comp_short_interval(start, pitch_roll):
+    """Test pitch_comp and roll_comp for short inteval during NPNT, NSUN, Safe Sun"""
+    stop = CxoTime(start) + 0.001 * u.s
+    dat = fetch_eng.Msid(f"{pitch_roll}_comp", start, stop)
+    assert len(dat) == 0
 
 
 @pytest.mark.parametrize("pitch_roll", ["pitch", "roll"])

--- a/cheta/tests/test_comps.py
+++ b/cheta/tests/test_comps.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+from cxotime import CxoTime
 from Quaternion import Quat
 
 from .. import fetch as fetch_cxc
@@ -285,6 +286,72 @@ def test_pitch_comp():
     )
     # fmt: on
     assert np.allclose(dat.vals, exp, rtol=0, atol=2e-2)
+
+
+@pytest.mark.parametrize("pitch_roll", ["pitch", "roll"])
+def test_pitch_roll_comp_short_npnt(pitch_roll):
+    """Test pitch_comp and roll_comp during a time with NPNT"""
+    # Sampled each 1.025 seconds
+    start = "2022:200:00:00:00.000"
+    stop = "2022:200:00:00:04.000"
+
+    dat = fetch_eng.Msid(f"{pitch_roll}_comp", start, stop)
+    if pitch_roll == "pitch":
+        exp_vals = [156.00595556, 156.00595083, 156.00595562, 156.00594386]
+    else:
+        exp_vals = [0.03759918, 0.03763989, 0.03770095, 0.03773727]
+    exp_dates = [
+        "2022:200:00:00:00.066",
+        "2022:200:00:00:01.091",
+        "2022:200:00:00:02.116",
+        "2022:200:00:00:03.141",
+    ]
+    assert np.all(CxoTime(dat.times).date == exp_dates)
+    assert np.allclose(dat.vals, exp_vals, rtol=0, atol=1e-4)
+
+
+@pytest.mark.parametrize("pitch_roll", ["pitch", "roll"])
+def test_pitch_roll_comp_short_nsun(pitch_roll):
+    """Test pitch/roll_comp during a time with NSUN"""
+    # Sampled each 4.1 seconds
+    start = "2022:295:18:00:00.000"
+    stop = "2022:295:18:00:16.000"
+
+    dat = fetch_eng.Msid(f"{pitch_roll}_comp", start, stop)
+    if pitch_roll == "pitch":
+        exp_vals = [90.15486, 90.1576, 90.178665, 90.18141]
+    else:
+        exp_vals = [-0.10997535, -0.10997537, -0.09622853, -0.09622855]
+    exp_dates = [
+        "2022:295:18:00:01.716",
+        "2022:295:18:00:05.816",
+        "2022:295:18:00:09.916",
+        "2022:295:18:00:14.016",
+    ]
+    assert np.all(CxoTime(dat.times).date == exp_dates)
+    assert np.allclose(dat.vals, exp_vals, rtol=0, atol=1e-4)
+
+
+@pytest.mark.parametrize("pitch_roll", ["pitch", "roll"])
+def test_pitch_roll_comp_short_safe_mode(pitch_roll):
+    """Test pitch/roll_comp during a time with NPNT"""
+    # Sampled each 0.25625 seconds
+    start = "2022:295:00:00:00.000"
+    stop = "2022:295:00:00:01.000"
+
+    dat = fetch_eng.Msid(f"{pitch_roll}_comp", start, stop)
+    if pitch_roll == "pitch":
+        exp_vals = [90.127625, 90.14162, 90.14162, 90.14162]
+    else:
+        exp_vals = [0.21003094, 0.20195293, 0.20195293, 0.20195293]
+    exp_dates = [
+        "2022:295:00:00:00.165",
+        "2022:295:00:00:00.421",
+        "2022:295:00:00:00.677",
+        "2022:295:00:00:00.934",
+    ]
+    assert np.all(CxoTime(dat.times).date == exp_dates)
+    assert np.allclose(dat.vals, exp_vals, rtol=0, atol=1e-4)
 
 
 def test_roll_comp():

--- a/cheta/tests/test_intervals.py
+++ b/cheta/tests/test_intervals.py
@@ -322,6 +322,11 @@ def test_logical_intervals_no_start_stop():
 
 
 def test_logical_intervals_start_stop_1():
+    """Test forcing start and stop values *outside* the times range.
+
+    Here the first state is False so the first interval is not affected by supplying
+    ``start``, but the last one will be since that state is True.
+    """
     times = np.arange(5)
     vals = np.array([0, 1, 1, 0, 1])
 
@@ -339,7 +344,11 @@ def test_logical_intervals_start_stop_1():
 
 
 def test_logical_intervals_start_stop_2():
-    """Test forcing start and stop values"""
+    """Test forcing start and stop values *outside* the times range.
+
+    Here the first and last states are True so the first/last interval should have
+    the supplied start/stop values respectively.
+    """
     times = np.arange(5)
     vals = np.array([1, 1, 1, 0, 1])
 
@@ -352,6 +361,23 @@ def test_logical_intervals_start_stop_2():
         "-------- ------ -----",
         "     3.5   -1.0   2.5",
         "     2.5    3.5   6.0",
+    ]
+    assert out.pformat_all() == exp
+
+
+def test_logical_intervals_start_stop_3():
+    """Test forcing start and stop values *inside* the times range."""
+    times = np.arange(5)
+    vals = np.array([0, 1, 1, 0, 1])
+
+    intervals = utils.logical_intervals(times, vals, start=1.2, stop=3.25)
+    out = intervals["duration", "tstart", "tstop"]
+    for name in out.colnames:
+        out[name].format = ".1f"
+    exp = [
+        "duration tstart tstop",
+        "-------- ------ -----",
+        "     1.3    1.2   2.5",
     ]
     assert out.pformat_all() == exp
 
@@ -411,10 +437,10 @@ def test_state_intervals_start_stop_1():
     exp = [
         "val duration tstart tstop",
         "--- -------- ------ -----",
-        "  0      1.0   -0.5   0.5",
+        "  0      1.5   -1.0   0.5",
         "  1      2.0    0.5   2.5",
         "  0      1.0    2.5   3.5",
-        "  1      1.0    3.5   4.5",
+        "  1      2.5    3.5   6.0",
     ]
     assert out.pformat_all() == exp
 
@@ -431,8 +457,28 @@ def test_state_intervals_start_stop_2():
     exp = [
         "val duration tstart tstop",
         "--- -------- ------ -----",
-        "  1      3.0   -0.5   2.5",
+        "  1      3.5   -1.0   2.5",
         "  0      1.0    2.5   3.5",
-        "  1      1.0    3.5   4.5",
+        "  1      2.5    3.5   6.0",
+    ]
+    assert out.pformat_all() == exp
+
+
+def test_state_intervals_start_stop_3():
+    """Test forcing start and stop values *inside* the times range."""
+    times = np.arange(5)
+    vals = np.array([10, 20, 30, 40, 50])
+
+    intervals = utils.state_intervals(times, vals, start=0.6, stop=3.9)
+    out = intervals["val", "duration", "tstart", "tstop"]
+    for name in out.colnames[1:]:
+        out[name].format = ".1f"
+    exp = [
+        "val duration tstart tstop",
+        "--- -------- ------ -----",
+        " 20      0.9    0.6   1.5",
+        " 30      1.0    1.5   2.5",
+        " 40      1.0    2.5   3.5",
+        " 50      0.4    3.5   3.9",
     ]
     assert out.pformat_all() == exp

--- a/cheta/tests/test_intervals.py
+++ b/cheta/tests/test_intervals.py
@@ -354,3 +354,85 @@ def test_logical_intervals_start_stop_2():
         "     2.5    3.5   6.0",
     ]
     assert out.pformat_all() == exp
+
+
+def test_state_intervals_no_values():
+    with pytest.raises(ValueError):
+        utils.state_intervals([], [])
+
+
+def test_state_intervals_one_value_error():
+    with pytest.raises(ValueError):
+        utils.state_intervals([1], [True])
+
+
+def test_state_intervals_one_value_true():
+    intervals = utils.state_intervals([1], [True], start=0, stop=2)
+    out = intervals["val", "duration", "tstart", "tstop"]
+    for name in out.colnames[1:]:
+        out[name].format = ".1f"
+    exp = [
+        "val  duration tstart tstop",
+        "---- -------- ------ -----",
+        "True      2.0    0.0   2.0",
+    ]
+    assert out.pformat_all() == exp
+
+
+def test_state_intervals_no_start_stop():
+    """
+    Test state_intervals function.
+    """
+    times = np.arange(5)
+    vals = np.array([0, 1, 1, 0, 1])
+    intervals = utils.state_intervals(times, vals)
+    out = intervals["val", "duration", "tstart", "tstop"]
+    for name in out.colnames[1:]:
+        out[name].format = ".1f"
+    exp = [
+        "val duration tstart tstop",
+        "--- -------- ------ -----",
+        "  0      1.0   -0.5   0.5",
+        "  1      2.0    0.5   2.5",
+        "  0      1.0    2.5   3.5",
+        "  1      1.0    3.5   4.5",
+    ]
+    assert out.pformat_all() == exp
+
+
+def test_state_intervals_start_stop_1():
+    times = np.arange(5)
+    vals = np.array([0, 1, 1, 0, 1])
+
+    intervals = utils.state_intervals(times, vals, start=-1, stop=6)
+    out = intervals["val", "duration", "tstart", "tstop"]
+    for name in out.colnames[1:]:
+        out[name].format = ".1f"
+    exp = [
+        "val duration tstart tstop",
+        "--- -------- ------ -----",
+        "  0      1.0   -0.5   0.5",
+        "  1      2.0    0.5   2.5",
+        "  0      1.0    2.5   3.5",
+        "  1      1.0    3.5   4.5",
+    ]
+    assert out.pformat_all() == exp
+
+
+def test_state_intervals_start_stop_2():
+    """Test forcing start and stop values"""
+    times = np.arange(5)
+    vals = np.array([1, 1, 1, 0, 1])
+
+    intervals = utils.state_intervals(times, vals, start=-1, stop=6)
+    out = intervals["val", "duration", "tstart", "tstop"]
+    for name in out.colnames[1:]:
+        out[name].format = ".1f"
+    exp = [
+        "val duration tstart tstop",
+        "--- -------- ------ -----",
+        "  1      3.0   -0.5   2.5",
+        "  0      1.0    2.5   3.5",
+        "  1      1.0    3.5   4.5",
+    ]
+    assert out.pformat_all() == exp

--- a/cheta/tests/test_intervals.py
+++ b/cheta/tests/test_intervals.py
@@ -261,3 +261,95 @@ def test_msid_state_intervals():
         "datestart", "datestop", "val"
     ]
     assert intervals.pformat() == expected
+
+
+def test_logical_intervals_no_values():
+    with pytest.raises(ValueError):
+        utils.logical_intervals([], [])
+
+
+def test_logical_intervals_one_value_error():
+    with pytest.raises(ValueError):
+        intervals = utils.logical_intervals([1], [True])
+
+def test_logical_intervals_one_value_true():
+    intervals = utils.logical_intervals([1], [True], start=0, stop=2)
+    out = intervals["duration", "tstart", "tstop"]
+    for name in out.colnames:
+        out[name].format = ".1f"
+    # fmt: off
+    exp = [
+        "duration tstart tstop",
+        "-------- ------ -----",
+        "     2.0    0.0   2.0"
+    ]
+    # fmt: on
+    assert out.pformat_all() == exp
+
+
+def test_logical_intervals_one_value_false():
+    intervals = utils.logical_intervals([1], [False], start=0, stop=2)
+    out = intervals["duration", "tstart", "tstop"]
+    for name in out.colnames:
+        out[name].format = ".1f"
+    # fmt: off
+    exp = [
+        "duration tstart tstop",
+        "-------- ------ -----",
+    ]
+    # fmt: on
+    assert out.pformat_all() == exp
+
+
+def test_logical_intervals_no_start_stop():
+    """
+    Test logical_intervals function.
+    """
+    times = np.arange(5)
+    vals = np.array([0, 1, 1, 0, 1])
+    intervals = utils.logical_intervals(times, vals)
+    out = intervals["duration", "tstart", "tstop"]
+    for name in out.colnames:
+        out[name].format = ".1f"
+    exp = [
+        "duration tstart tstop",
+        "-------- ------ -----",
+        "     2.0    0.5   2.5",
+        "     1.0    3.5   4.5",
+    ]
+    assert out.pformat_all() == exp
+
+
+def test_logical_intervals_start_stop_1():
+    times = np.arange(5)
+    vals = np.array([0, 1, 1, 0, 1])
+
+    intervals = utils.logical_intervals(times, vals, start=-1, stop=6)
+    out = intervals["duration", "tstart", "tstop"]
+    for name in out.colnames:
+        out[name].format = ".1f"
+    exp = [
+        "duration tstart tstop",
+        "-------- ------ -----",
+        "     2.0    0.5   2.5",
+        "     2.5    3.5   6.0",
+    ]
+    assert out.pformat_all() == exp
+
+
+def test_logical_intervals_start_stop_2():
+    """Test forcing start and stop values"""
+    times = np.arange(5)
+    vals = np.array([1, 1, 1, 0, 1])
+
+    intervals = utils.logical_intervals(times, vals, start=-1, stop=6)
+    out = intervals["duration", "tstart", "tstop"]
+    for name in out.colnames:
+        out[name].format = ".1f"
+    exp = [
+        "duration tstart tstop",
+        "-------- ------ -----",
+        "     3.5   -1.0   2.5",
+        "     2.5    3.5   6.0",
+    ]
+    assert out.pformat_all() == exp

--- a/cheta/tests/test_intervals.py
+++ b/cheta/tests/test_intervals.py
@@ -270,7 +270,8 @@ def test_logical_intervals_no_values():
 
 def test_logical_intervals_one_value_error():
     with pytest.raises(ValueError):
-        intervals = utils.logical_intervals([1], [True])
+        utils.logical_intervals([1], [True])
+
 
 def test_logical_intervals_one_value_true():
     intervals = utils.logical_intervals([1], [True], start=0, stop=2)

--- a/cheta/tests/test_utils.py
+++ b/cheta/tests/test_utils.py
@@ -138,3 +138,15 @@ def test_get_telem_table(dt):
     }
 
     assert dat.pformat_all() == exp[dt]
+
+
+@pytest.mark.parametrize("unit_system", ["eng", "cxc", "sci", None])
+def test_get_telem_table_units(unit_system):
+    """Test getting telemetry with different unit systems"""
+    start = CxoTime("2023:001:00:00:00.000")
+    stop = start + 32.8 * u.s
+    kwargs = {"unit_system": unit_system} if unit_system else {}
+    dat = get_telem_table(["aacccdpt"], start, stop, **kwargs)
+
+    exp = {"eng": 19.54, "cxc": 266.23, "sci": -6.92, None: 19.54}
+    assert dat["aacccdpt"][0] == pytest.approx(exp[unit_system], abs=0.01)

--- a/cheta/tests/test_utils.py
+++ b/cheta/tests/test_utils.py
@@ -1,8 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import astropy.units as u
 import numpy as np
+import pytest
+from cxotime import CxoTime
 
-from .. import fetch
-from ..utils import get_fetch_size
+from cheta import fetch
+from cheta.utils import (
+    get_fetch_size,
+    get_ofp_states,
+    get_telem_table,
+    NoTelemetryError,
+)
 
 
 def test_get_fetch_size_functionality():
@@ -67,3 +75,67 @@ def test_get_fetch_size_accuracy():
     dat.interpolate(328.0 * 2)
     fetch_bytes = sum(getattr(dat, attr).nbytes for attr in dat.colnames)
     assert np.isclose(out_mb, fetch_bytes / 1e6, rtol=0.0, atol=0.01)
+
+
+def test_get_ofp_states():
+    out = get_ofp_states("2022:292", "2022:297")
+    # Reference values take from original implementation of get_ofp_states in kadi.utils
+    # *except* that start and stop values now match the supplied start/stop.
+    exp = [
+        "      datestart              datestop       val ",
+        "--------------------- --------------------- ----",
+        "2022:292:00:00:00.000 2022:293:16:27:57.429 NRML",
+        "2022:293:16:27:57.429 2022:293:16:27:59.479 STUP",
+        "2022:293:16:27:59.479 2022:293:16:28:00.504 SYON",
+        "2022:293:16:28:00.504 2022:294:16:32:25.285 NRML",
+        "2022:294:16:32:25.285 2022:294:16:32:27.347 STUP",
+        "2022:294:16:33:01.794 2022:295:16:48:09.260 SAFE",
+        "2022:295:16:48:09.260 2022:295:16:49:49.722 STUP",
+        "2022:295:16:50:22.339 2022:295:17:22:56.002 STUP",
+        "2022:295:17:22:56.002 2022:295:17:22:57.027 SYSF",
+        "2022:295:17:22:57.027 2022:295:17:41:01.477 SAFE",
+        "2022:295:17:41:01.477 2022:297:00:00:00.000 NRML",
+    ]
+
+    assert out["datestart", "datestop", "val"].pformat_all() == exp
+
+
+@pytest.mark.parametrize("dt", [0.001, 1.0])
+def test_get_ofp_states_safe_mode_short(dt):
+    """Test getting OFP states where the time range is within the SAFE mode and
+    there is zero or one sample of CONLOFP in the range."""
+    start = CxoTime("2022:295")
+    stop = start + dt * u.s
+    out = get_ofp_states(start, stop)
+    secs = {0.001: "00.001", 1.0: "01.000"}[dt]
+    exp = [
+        "      datestart              datestop       val ",
+        "--------------------- --------------------- ----",
+        f"2022:295:00:00:00.000 2022:295:00:00:{secs} SAFE",
+    ]
+
+    assert out["datestart", "datestop", "val"].pformat_all() == exp
+
+
+@pytest.mark.parametrize("dt", [0.001, 1.0])
+def test_get_telem_table(dt):
+    """Test getting telemetry where the time range is within the sampling of one
+    of the secondary MSIDs."""
+    start = CxoTime("2022:295:00:00:00.000")
+    stop = start + dt * u.s
+    dat = get_telem_table(["conlofp", "orbitephem0_x"], start, stop)
+    dat["orbitephem0_x"].info.format = ".2f"
+
+    exp = {
+        1.0: [  # One sample in primary MSID
+            "     time     conlofp orbitephem0_x",
+            "------------- ------- -------------",
+            "782784069.605    SAFE  -13267583.62",
+        ],
+        0.001: [  # No samples in primary MSID
+            "time conlofp orbitephem0_x",
+            "---- ------- -------------",
+        ],
+    }
+
+    assert dat.pformat_all() == exp[dt]

--- a/cheta/tests/test_utils.py
+++ b/cheta/tests/test_utils.py
@@ -9,7 +9,6 @@ from cheta.utils import (
     get_fetch_size,
     get_ofp_states,
     get_telem_table,
-    NoTelemetryError,
 )
 
 

--- a/cheta/units.py
+++ b/cheta/units.py
@@ -37,14 +37,12 @@ Basic units handling and conversion.
  ('VDC', 'V'),
  ('W', 'W')}
 """
-from __future__ import absolute_import, division, print_function
-
 import logging
 import os
 import warnings
 
 import numpy as np
-from six.moves import cPickle as pickle
+import pickle
 
 
 class NullHandler(logging.Handler):

--- a/cheta/utils.py
+++ b/cheta/utils.py
@@ -2,18 +2,27 @@
 """
 Utilities for the engineering archive.
 """
+import functools
 import re
 from contextlib import contextmanager
 
+import astropy.units as u
 import numpy as np
 import six
+from astropy.table import Table
 from Chandra.Time import DateTime
+from cheta import fetch, fetch_eng
+from cxotime import CxoTime, CxoTimeLike
 
 # Cache the results of fetching 3 days of telemetry keyed by MSID
 FETCH_SIZES = {}
 
 # Standard intervals for 5min and daily telemetry
 STATS_DT = {"5min": 328, "daily": 86400}
+
+
+class NoTelemetryError(Exception):
+    """No telemetry available for the specified interval"""
 
 
 def get_fetch_size(msids, start, stop, stat=None, interpolate_dt=None, fast=True):
@@ -242,7 +251,9 @@ def _pad_long_gaps(times, bools, max_gap):
     return times, bools
 
 
-def logical_intervals(times, bools, complete_intervals=False, max_gap=None):
+def logical_intervals(
+    times, bools, complete_intervals=False, max_gap=None, start=None, stop=None
+):
     """Determine contiguous intervals during which `bools` is True.
 
     If ``complete_intervals`` is True (default is False) then the intervals are
@@ -252,6 +263,9 @@ def logical_intervals(times, bools, complete_intervals=False, max_gap=None):
     If ``max_gap`` is specified then any time gaps longer than ``max_gap`` are
     filled with a fictitious False value to create an artificial interval
     boundary at ``max_gap / 2`` seconds from the nearest data value.
+
+    If ``start`` is specified then the first interval will be from ``start``. If
+    ``stop`` is specified then the last interval will be to ``stop``.
 
     Returns an astropy Table with a row for each interval.  Columns are:
 
@@ -281,12 +295,18 @@ def logical_intervals(times, bools, complete_intervals=False, max_gap=None):
     :param bools: array of logical True/False values
     :param complete_intervals: return only complete intervals (default=True)
     :param max_gap: max allowed gap between time stamps (sec, default=None)
+    :param start: start time (CxoTimeLike, default=None)
+    :param stop: stop time (CxoTimeLike, default=None)
+
     :returns: Table of intervals
     """
+    times = np.asarray(times, dtype=float)
+    bools = np.asarray(bools, dtype=bool)
+
     if max_gap is not None:
         times, bools = _pad_long_gaps(times, bools, max_gap)
 
-    intervals = state_intervals(times, bools)
+    intervals = state_intervals(times, bools, start=start, stop=stop)
 
     if complete_intervals:
         if len(intervals) > 0 and intervals["val"][0]:
@@ -299,7 +319,7 @@ def logical_intervals(times, bools, complete_intervals=False, max_gap=None):
     return intervals[ok]
 
 
-def state_intervals(times, vals):
+def state_intervals(times, vals, start=None, stop=None):
     """
     Determine contiguous intervals during which the ``vals`` is unchanged.
 
@@ -311,6 +331,9 @@ def state_intervals(times, vals):
     * tstart: time of interval start (CXC sec)
     * tstop: time of interval stop (CXC sec)
     * val: MSID value during the interval
+
+    If ``start`` is specified then the first interval will be from ``start``. If
+    ``stop`` is specified then the last interval will be to ``stop``.
 
     Example::
 
@@ -326,31 +349,169 @@ def state_intervals(times, vals):
 
     :param times: times (CXC seconds)
     :param vals: state values for which intervals are returned.
+    :param start: start time (CxoTimeLike, default=None)
+    :param stop: stop time (CxoTimeLike, default=None)
     :returns: structured array table of intervals
     """
     from astropy.table import Table
 
-    if len(vals) < 2:
-        raise ValueError("Filtered data length must be at least 2")
+    times = np.asarray(times, dtype=float)
+    vals = np.asarray(vals)
 
-    transitions = np.hstack([[True], vals[:-1] != vals[1:], [True]])
-    t0 = times[0] - (times[1] - times[0]) / 2
-    t1 = times[-1] + (times[-1] - times[-2]) / 2
-    midtimes = np.hstack([[t0], (times[:-1] + times[1:]) / 2, [t1]])
+    if start is not None:
+        start = CxoTime(start)
 
-    state_vals = vals[transitions[1:]]
-    state_times = midtimes[transitions]
+    if stop is not None:
+        stop = CxoTime(stop)
 
-    intervals = {
-        "datestart": DateTime(state_times[:-1]).date,
-        "datestop": DateTime(state_times[1:]).date,
-        "tstart": state_times[:-1],
-        "tstop": state_times[1:],
-        "duration": state_times[1:] - state_times[:-1],
-        "val": state_vals,
-    }
+    if len(vals) == 0:
+        raise ValueError("data length must be at least 1")
 
-    return Table(intervals, names=sorted(intervals))
+    if len(vals) == 1:
+        if start is None or stop is None:
+            raise ValueError(
+                "For data length of 1, `start` and `stop` must be specified"
+            )
+
+        intervals = {
+            "datestart": [start.date],
+            "datestop": [stop.date],
+            "tstart": [start.secs],
+            "tstop": [stop.secs],
+            "duration": [stop.secs - start.secs],
+            "val": vals,
+        }
+
+    else:
+        transitions = np.hstack([[True], vals[:-1] != vals[1:], [True]])
+        t0 = times[0] - (times[1] - times[0]) / 2
+        t1 = times[-1] + (times[-1] - times[-2]) / 2
+        midtimes = np.hstack([[t0], (times[:-1] + times[1:]) / 2, [t1]])
+
+        state_vals = vals[transitions[1:]]
+        state_times = midtimes[transitions]
+
+        # Telemetry data may be provided that is outside the start/stop range. Here we
+        # clip the state_times to be within the start/stop range. Any states that are
+        # fully outside the range will have a duration of 0.0 sec and will be removed.
+        if start is not None:
+            state_times = state_times.clip(start.secs, None)
+        if stop is not None:
+            state_times = state_times.clip(None, stop.secs)
+
+        intervals = {
+            "datestart": CxoTime(state_times[:-1]).date,
+            "datestop": CxoTime(state_times[1:]).date,
+            "tstart": state_times[:-1],
+            "tstop": state_times[1:],
+            "duration": state_times[1:] - state_times[:-1],
+            "val": state_vals,
+        }
+
+    out = Table(intervals, names=sorted(intervals))
+
+    # Remove intervals that are outside the start/stop range
+    bad = out["duration"] <= 0.0
+    if np.any(bad):
+        out = out[~bad]
+
+    out["tstart"].info.format = ".3f"
+    out["tstop"].info.format = ".3f"
+    out["duration"].info.format = ".3f"
+
+    return out
+
+
+def get_telem_table(
+    msids: list,
+    start: CxoTimeLike,
+    stop: CxoTimeLike,
+    time_pad: u.Quantity = 15 * u.min,
+) -> Table:
+    """
+    Fetch telemetry for a list of MSIDs and return as an Astropy Table.
+
+    This interpolates all the MSIDs to the time base of the first MSID in the list. It
+    also fetches ``time_pad`` more than requested to ensure that the samples are
+    complete (e.g. if the interval is between MSID samples).
+
+    If no telemetry is available for the requested interval then an empty table is
+    returned with all float columns.
+
+    :param msids: fetch msids list
+    :param start: start time for telemetry (CxoTime-like)
+    :param stop: stop time for telemetry (CxoTime-like)
+    :param time_pad: Quantity time pad on each end for fetch (default=15 min)
+
+    :returns: Table of requested telemetry values from fetch
+    """
+    start = CxoTime(start)
+    stop = CxoTime(stop)
+    names = ["time"] + msids
+
+    # Get the MSIDset for the requested MSIDs and time range with some padding to
+    # ensure samples even for slow MSIDS like ephemeris at 5-min cadence.
+    msidset = fetch_eng.MSIDset(msids, start - time_pad, stop + time_pad)
+
+    if any(len(msidset[msid]) == 0 for msid in msids):
+        # If no telemetry was found then return an empty table with the expected names
+        # but all float64 columns.
+        out = Table(names=names)
+        return out
+
+    # Use the first MSID as the primary one to set the time base
+    msid0 = msidset[msids[0]]
+    times = msid0.times
+    i0, i1 = np.searchsorted(times, [start.secs, stop.secs])
+    times = times[i0:i1]
+
+    msidset.interpolate(times=times, bad_union=True)
+
+    out = Table([msidset.times] + [msidset[x].vals for x in msids], names=names)
+    out["time"].info.format = ".3f"
+
+    return out
+
+
+@functools.lru_cache(maxsize=1)
+def get_ofp_states(start, stop):
+    """Get the Onboard Flight Program (OFP) states between ``start`` and ``stop`.
+
+    This is normally "NRML" but in safe mode it is "SAFE" or other values. State codes:
+    ['NNRM' 'STDB' 'STBS' 'NRML' 'NSTB' 'SUOF' 'SYON' 'DPLY' 'SYSF' 'STUP' 'SAFE']
+
+    :param start: start time (CxoTimeLike)
+    :param stop: stop time (CxoTimeLike)
+    :returns: astropy Table of OFP state intervals
+    """
+    from astropy.table import vstack
+
+    start = CxoTime(start)
+    stop = CxoTime(stop)
+
+    msid = "conlofp"
+    tlm = get_telem_table([msid], start - 30 * u.s, stop + 30 * u.s)
+
+    if len(tlm) == 0:
+        raise NoTelemetryError(f"No telemetry for {msid} between {start} and {stop}")
+
+    states_list = []
+    for state_code in np.unique(tlm[msid]):
+        states = logical_intervals(
+            tlm["time"],
+            tlm[msid] == state_code,
+            max_gap=2.1,
+            complete_intervals=False,
+            start=start,
+            stop=stop,
+        )
+        states["val"] = state_code
+        states_list.append(states)
+
+    states = vstack(states_list)
+    states.sort("datestart")
+
+    return states
 
 
 def get_date_id(date):

--- a/cheta/utils.py
+++ b/cheta/utils.py
@@ -414,6 +414,17 @@ def state_intervals(times, vals, start=None, stop=None):
     if np.any(bad):
         out = out[~bad]
 
+    # Potentially adjust the first and last intervals to be from start/stop.
+    if len(out) > 0:
+        if start is not None:
+            out["datestart"][0] = start.date
+            out["tstart"][0] = start.secs
+        if stop is not None:
+            out["datestop"][-1] = stop.date
+            out["tstop"][-1] = stop.secs
+        out["duration"][0] = out["tstop"][0] - out["tstart"][0]
+        out["duration"][-1] = out["tstop"][-1] - out["tstart"][-1]
+
     out["tstart"].info.format = ".3f"
     out["tstop"].info.format = ".3f"
     out["duration"].info.format = ".3f"

--- a/cheta/utils.py
+++ b/cheta/utils.py
@@ -11,8 +11,9 @@ import numpy as np
 import six
 from astropy.table import Table
 from Chandra.Time import DateTime
-from cheta import fetch, fetch_eng
 from cxotime import CxoTime, CxoTimeLike
+
+from cheta import fetch_eng
 
 # Cache the results of fetching 3 days of telemetry keyed by MSID
 FETCH_SIZES = {}


### PR DESCRIPTION
## Description

This is a hodge-podge of related improvements to utilities in cheta. The initial driver was a problem in `[aca] Kadi commands state validation: ALERT` on Apr 1 ending with:
```
 File "/proj/sot/ska3/flight/lib/python3.10/site-packages/cheta/utils.py", line 334, in state_intervals
    raise ValueError("Filtered data length must be at least 2")
ValueError: Filtered data length must be at least 2
```

Generally speaking the original implementation of `pitch_comp` and `roll_comp` was not robust. It depended on `get_ofp_states` in `kadi.utils` which was also not robust. So this turned into an effort to revisit this code and make it work under most circumstances. In particular dealing with short query intervals was a focus.

Since the code hinges on `state_intervals` and `logical_intervals`, those got pulled into the effort.

This is used by https://github.com/sot/kadi/pull/285.

### Changes
- Fix `pitch_comp` and `roll_comp` to work for short query intervals like normal MSIDs, namely to return values if the interval covers a time where the relevant primary telemetry are available. Since this computation uses telemetry sampled from 1.025 sec up to 5 minutes (ephemeris), this is not completely trivial. In any case it should always return a result, even if that result has no data. Added new tests of this.
- Add `start` and `stop` args to `logical_intervals` and `state_intervals`. This is useful when you want the table to states to exactly span the requested interval. This is different from the default behavior where the states start and end times are defined by the input times.
- For `logical_intervals` and `state_intervals` provide special handling for cases with input data of length 0 and 1. Previously you would get some non-obvious exceptions.
- Add the `get_telem_table` function which was migrated and generalized somewhat from the kadi validate code.

TODO:
- [x] Add more tests for `state_intervals`

Fixes #247

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by Jean
- [x] Linux (fido)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
