### PR TITLE
Fix problems that came up in `pitch/roll-comp` when using real-time data

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: "3.10"
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -668,7 +668,7 @@ def calc_pitch_roll_obc(tstart: float, tstop: float, pitch_roll: str):
     # Filter bad data values
     tlm.interpolate(times=tlm.times)
     tlm.bads = np.zeros(len(tlm.times), dtype=bool)
-    
+
     vals = dp.calc(tlm)
     i0, i1 = np.searchsorted(tlm.times, [tstart, tstop])
     return tlm.times[i0:i1], vals[i0:i1]

--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -665,7 +665,9 @@ def calc_pitch_roll_obc(tstart: float, tstop: float, pitch_roll: str):
     # Pad by 12 minutes on each side to ensure ephemeris data are available.
     tlm = dp.fetch(tstart - 720, tstop + 720)
 
-    # Filter bad data values
+    # Filter bad data values. The `dp.fetch` above sets bad over intervals where any of
+    # the inputs are missing and calling interpolate like below will cut those out.
+    # See PR #250 for more details.
     tlm.interpolate(times=tlm.times)
     tlm.bads = np.zeros(len(tlm.times), dtype=bool)
 
@@ -744,7 +746,8 @@ class Comp_Pitch_Roll_OBC_Safe(ComputedMsid):
                     tlms.append((np.array([], dtype=float), np.array([], dtype=float)))
                     continue
 
-                # Get states of either NPNT / NMAN or NSUN
+                # Get states of either NPNT / NMAN or NSUN which cover exactly the
+                # time span of the ofp_state interval.
                 vals = np.isin(dat.vals, ["NPNT", "NMAN"])
                 states_npnt_nman = logical_intervals(
                     dat.times,


### PR DESCRIPTION
## Description

Using MAUDE data just after a comm for the `pitch_comp` and `roll_comp` computed MSIDs was failing for a couple of reasons:
- There was a 1-sample (2.05 sec) CONLOFP state that caused a problem in `state_intervals`. This was fixed by specifying the `start` and `stop` times (enabled by #249).
- The chunk of time after the comm where ephemeris data are available but no quaternions was being marked as bad by the telemetry fetching code but that was being used in subsequent processing to just set the `pitch` or `roll` to 0.0. Instead the data points need to be removed entirely. The updated code does this now.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Using this branch I ran a fetch query for `pitch_comp` about one hour after BOT. The query started before the comm and ended at the current time (after the comm). Before the fix this either failed completely (without the CONLOFP fix) or returned a bunch of 0.0 values at the end. After the fix I saw the expected pitch values.

