### PR TITLE
Add a negative lookahead assertion for log check

### DIFF
--- a/cheta/task_schedule.cfg
+++ b/cheta/task_schedule.cfg
@@ -47,8 +47,8 @@ alert       aca@head.cfa.harvard.edu
         <error>
           #    File           Expression
           #  ----------      ---------------------------
-             eng_archive.log     error
-             eng_archive.log     warning
+             eng_archive.log     error(?! (back trace|message =))
+             eng_archive.log     warning(?!: open_file)
              eng_archive.log     fatal
         </error>
       </check>


### PR DESCRIPTION
## Description

The HDF5 retry errors should not generate an alert email.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests (for task-schedule code)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
The `watch_cron_logs3.pl` documentation shows an example which indicates this regex and syntax should be valid:
```
<check>
 	<error>
              #    File           Expression
              #  ----------      ---------------------------
 		*		Use of uninitialized value
 		*		(?<!Program caused arithmetic )Error
 		*		Warning
                 *               fatal
 	</error>
</check>
```

Ran the following Python script to verify the regex's are good. The unwanted lines with `error` or `warning` are not matched, while other `error` or `warning` lines are matched.

The text is adapted from an alert email today, with a couple of extra lines added.
```
import re

text = """
warning: could not open file!
WARNING: open_file(/proj/sot/ska3/flight/data/eng_archive/data/acis2eng/5min/1DEAMZT.h5, mode=a, filters=Filters(complevel=5, complib='zlib', shuffle=True, bitshuffle=False, fletcher32=False, least_significant_digit=None)) exception: HDF5 error back trace

  File "H5F.c", line 620, in H5Fopen
    unable to open file
  File "H5VLcallback.c", line 3501, in H5VL_file_open
    failed to iterate over available VOL connector plugins
  File "H5PLpath.c", line 578, in H5PL__path_table_iterate
    can't iterate over plugins in plugin path '(null)'
  File "H5PLpath.c", line 620, in H5PL__path_table_iterate_process_path
    can't open directory: /proj/sot/ska3/flight/lib/hdf5/plugin
  File "H5VLcallback.c", line 3351, in H5VL__file_open
    open failed
  File "H5VLnative_file.c", line 97, in H5VL__native_file_open
    unable to open file
  File "H5Fint.c", line 1898, in H5F_open
    unable to lock the file
  File "H5FD.c", line 1625, in H5FD_lock
    driver lock request failed
  File "H5FDsec2.c", line 1002, in H5FD__sec2_lock
    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
Error Message:
  unable to lock file
End of HDF5 error back trace
"""

lines = text.split('\n')

regex = re.compile("error(?! (back trace|message =))", re.IGNORECASE)
print(regex)
for line in lines:
    if regex.search(line):
        print(line)

print()

regex = re.compile("warning(?!: open_file)", re.IGNORECASE)
print(regex)
for line in lines:
    if regex.search(line):
        print(line)
```
Output:
```
$ python check_error_regex.py
re.compile('error(?! (back trace|message =))', re.IGNORECASE)
Error Message:

re.compile('warning(?!: open_file)', re.IGNORECASE)
warning: could not open file!
```

