### PR TITLE
Replace np.bool with bool

### DIFF
--- a/cheta/converters.py
+++ b/cheta/converters.py
@@ -74,8 +74,8 @@ def generic_converter(prefix=None, add_quality=False, aliases=None):
 
         if add_quality:
             descrs = [(x,) + y[1:] for x, y in zip(colnames_out, dat.dtype.descr)]
-            quals = numpy.zeros((len(dat), len(colnames) + 1), dtype=numpy.bool)
-            descrs += [("QUALITY", numpy.bool, (len(colnames) + 1,))]
+            quals = numpy.zeros((len(dat), len(colnames) + 1), dtype=bool)
+            descrs += [("QUALITY", bool, (len(colnames) + 1,))]
             arrays += [quals]
         else:
             descrs = [
@@ -563,7 +563,7 @@ def acisdeahk(dat):
         quality = (False, False) + bads
         outs.append((times[i0], quality) + vals)
 
-    dtype = [("TIME", numpy.float64), ("QUALITY", numpy.bool, (len(col_names) + 2,))]
+    dtype = [("TIME", numpy.float64), ("QUALITY", bool, (len(col_names) + 2,))]
     dtype += [(col_name, numpy.float32) for col_name in col_names]
 
     return numpy.rec.fromrecords(outs, dtype=dtype)

--- a/cheta/tests/test_comps.py
+++ b/cheta/tests/test_comps.py
@@ -205,7 +205,7 @@ def test_cmd_states():
             173.38189234,
         ]
     )
-    assert np.allclose(dat.vals, exp_vals)
+    assert np.allclose(dat.vals, exp_vals, rtol=0, atol=1e-3)
     assert type(dat.vals) is np.ndarray
     assert np.allclose(np.diff(dat.times), 1025.0)
     assert not np.any(dat.bads)

--- a/cheta/tests/test_comps.py
+++ b/cheta/tests/test_comps.py
@@ -205,7 +205,7 @@ def test_cmd_states():
             173.38189234,
         ]
     )
-    assert np.allclose(dat.vals, exp_vals, rtol=0, atol=1e-3)
+    assert np.allclose(dat.vals, exp_vals)
     assert type(dat.vals) is np.ndarray
     assert np.allclose(np.diff(dat.times), 1025.0)
     assert not np.any(dat.bads)

--- a/cheta/update_archive.py
+++ b/cheta/update_archive.py
@@ -1001,7 +1001,7 @@ def read_derived(i, filename, filetype, row, colnames, archfiles, db):
 
     logger.info("Reading (%d / %d) %s" % (i, len(archfiles), filename))
     vals = {}
-    bads = np.zeros((len(times), len(colnames)), dtype=np.bool)
+    bads = np.zeros((len(times), len(colnames)), dtype=bool)
     for i, colname in enumerate(colnames):
         if colname == "TIME":
             vals[colname] = times


### PR DESCRIPTION
## Description

These are updates motivated by test warnings in our draft "speedy" Python 3.11 candidate environment.

Replace np.bool with bool (deprecated use of np.bool is an error in the speedy candidate).


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux with ska3-masters and ska3-flight-2024.0rc7

```
(ska3-flight-2024.0rc7) jeanconn-fido> git rev-parse HEAD
55c4676df457f4b099c09234ebc1a86d60ee7eba
(ska3-flight-2024.0rc7) jeanconn-fido> pytest
========================================================== test session starts ==========================================================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /proj/sot/ska/jeanproj/git/cheta
plugins: timeout-2.2.0, anyio-4.2.0
collected 173 items                                                                                                                     

cheta/tests/test_comps.py ...........................................................                                             [ 34%]
cheta/tests/test_data_source.py .........                                                                                         [ 39%]
cheta/tests/test_fetch.py ................................                                                                        [ 57%]
cheta/tests/test_intervals.py .........................                                                                           [ 72%]
cheta/tests/test_orbit.py .                                                                                                       [ 72%]
cheta/tests/test_remote_access.py ......                                                                                          [ 76%]
cheta/tests/test_sync.py ........                                                                                                 [ 80%]
cheta/tests/test_units.py ...........                                                                                             [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                    [ 93%]
cheta/tests/test_utils.py ...........                                                                                             [100%]

=========================================================== warnings summary ============================================================
../../../../../../fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/ska_helpers/version.py:25
  /fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/ska_helpers/version.py:25: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import DistributionNotFound, get_distribution

../../../../../../fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/pkg_resources/__init__.py:2868
  /fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../../../../../fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/jupyter_client/connect.py:27
  /fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir

cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== 173 passed, 5 warnings in 299.56s (0:04:59
```

```
(ska3-masters) jeanconn-fido> git rev-parse HEAD
55c4676df457f4b099c09234ebc1a86d60ee7eba
(ska3-masters) jeanconn-fido> pytest
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git/cheta
plugins: timeout-2.1.0, anyio-3.6.2
collected 173 items                                                                                                                                                        

cheta/tests/test_comps.py ...........................................................                                                                                [ 34%]
cheta/tests/test_data_source.py .........                                                                                                                            [ 39%]
cheta/tests/test_fetch.py ................................                                                                                                           [ 57%]
cheta/tests/test_intervals.py .........................                                                                                                              [ 72%]
cheta/tests/test_orbit.py .                                                                                                                                          [ 72%]
cheta/tests/test_remote_access.py ......                                                                                                                             [ 76%]
cheta/tests/test_sync.py ........                                                                                                                                    [ 80%]
cheta/tests/test_units.py ...........                                                                                                                                [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                                                       [ 93%]
cheta/tests/test_utils.py ...........                                                                                                                                [100%]

============================================================================= warnings summary =============================================================================
../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/jupyter_client/connect.py:27
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir

../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21
../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_forbids_neg_powint = LooseVersion(numpy.__version__) >= LooseVersion('1.12.0b1')

cheta/tests/test_comps.py::test_mups_valve
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numpy/ctypeslib.py:137: DeprecationWarning: 
  
    `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
    of the deprecation of `distutils` itself. It will be removed for
    Python >= 3.12. For older Python versions it will remain present.
    It is recommended to use `setuptools < 60.0` for those Python versions.
    For more details, see:
      https://numpy.org/devdocs/reference/distutils_status_migration.html 
  
  
    from numpy.distutils.misc_util import get_shared_lib_extension

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 173 passed, 4 warnings in 335.81s (0:05:35)
```


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
