### PR TITLE
Convert remaining np.bool to bool

### DIFF
--- a/cheta/converters.py
+++ b/cheta/converters.py
@@ -142,7 +142,7 @@ def generic_converter2(msid_cxc_map, default_dtypes=None):
     def _convert(dat):
         # Make quality bool array with entries for TIME, QUALITY, then all other cols
         out_names = ["TIME", "QUALITY"] + list(msid_cxc_map.keys())
-        out_quality = np.zeros(shape=(len(dat), len(out_names)), dtype=np.bool)
+        out_quality = np.zeros(shape=(len(dat), len(out_names)), dtype=bool)
         out_arrays = {"TIME": dat["TIME"], "QUALITY": out_quality}
 
         for out_name, in_name in msid_cxc_map.items():

--- a/cheta/fetch.py
+++ b/cheta/fetch.py
@@ -1902,7 +1902,7 @@ class HrcSsMsid(Msid):
         out = MSIDset(msids, start=start, stop=stop, stat=stat)
         if stat is not None:
             for m in msids:
-                out[m].bads = np.zeros(len(out[m].vals), dtype=np.bool)
+                out[m].bads = np.zeros(len(out[m].vals), dtype=bool)
 
         # Set bad mask
         i_bads = np.flatnonzero(out["HRC_SS_HK_BAD"].vals > 0)


### PR DESCRIPTION
## Description

Convert two remaining instances of `np.bool` to `bool`.

See: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. These deprecations are errors as of numpy 1.26. The code here is not covered in unit testing unfortunately.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
