### PR TITLE
replace uses of pformat_all with pformat

### DIFF
--- a/cheta/tests/test_intervals.py
+++ b/cheta/tests/test_intervals.py
@@ -285,7 +285,7 @@ def test_logical_intervals_one_value_true():
         "     2.0    0.0   2.0"
     ]
     # fmt: on
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_logical_intervals_one_value_false():
@@ -299,7 +299,7 @@ def test_logical_intervals_one_value_false():
         "-------- ------ -----",
     ]
     # fmt: on
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_logical_intervals_no_start_stop():
@@ -318,7 +318,7 @@ def test_logical_intervals_no_start_stop():
         "     2.0    0.5   2.5",
         "     1.0    3.5   4.5",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_logical_intervals_start_stop_1():
@@ -340,7 +340,7 @@ def test_logical_intervals_start_stop_1():
         "     2.0    0.5   2.5",
         "     2.5    3.5   6.0",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_logical_intervals_start_stop_2():
@@ -362,7 +362,7 @@ def test_logical_intervals_start_stop_2():
         "     3.5   -1.0   2.5",
         "     2.5    3.5   6.0",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_logical_intervals_start_stop_3():
@@ -379,7 +379,7 @@ def test_logical_intervals_start_stop_3():
         "-------- ------ -----",
         "     1.3    1.2   2.5",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_state_intervals_no_values():
@@ -402,7 +402,7 @@ def test_state_intervals_one_value_true():
         "---- -------- ------ -----",
         "True      2.0    0.0   2.0",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_state_intervals_no_start_stop():
@@ -423,7 +423,7 @@ def test_state_intervals_no_start_stop():
         "  0      1.0    2.5   3.5",
         "  1      1.0    3.5   4.5",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_state_intervals_start_stop_1():
@@ -442,7 +442,7 @@ def test_state_intervals_start_stop_1():
         "  0      1.0    2.5   3.5",
         "  1      2.5    3.5   6.0",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_state_intervals_start_stop_2():
@@ -461,7 +461,7 @@ def test_state_intervals_start_stop_2():
         "  0      1.0    2.5   3.5",
         "  1      2.5    3.5   6.0",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp
 
 
 def test_state_intervals_start_stop_3():
@@ -481,4 +481,4 @@ def test_state_intervals_start_stop_3():
         " 40      1.0    2.5   3.5",
         " 50      0.4    3.5   3.9",
     ]
-    assert out.pformat_all() == exp
+    assert out.pformat() == exp

--- a/cheta/tests/test_utils.py
+++ b/cheta/tests/test_utils.py
@@ -96,7 +96,7 @@ def test_get_ofp_states():
         "2022:295:17:41:01.477 2022:297:00:00:00.000 NRML",
     ]
 
-    assert out["datestart", "datestop", "val"].pformat_all() == exp
+    assert out["datestart", "datestop", "val"].pformat() == exp
 
 
 @pytest.mark.parametrize("dt", [0.001, 1.0])
@@ -113,7 +113,7 @@ def test_get_ofp_states_safe_mode_short(dt):
         f"2022:295:00:00:00.000 2022:295:00:00:{secs} SAFE",
     ]
 
-    assert out["datestart", "datestop", "val"].pformat_all() == exp
+    assert out["datestart", "datestop", "val"].pformat() == exp
 
 
 @pytest.mark.parametrize("dt", [0.001, 1.0])
@@ -137,7 +137,7 @@ def test_get_telem_table(dt):
         ],
     }
 
-    assert dat.pformat_all() == exp[dt]
+    assert dat.pformat() == exp[dt]
 
 
 @pytest.mark.parametrize("unit_system", ["eng", "cxc", "sci", None])


### PR DESCRIPTION
## Description

This is a change intended for skare3 > 2025.0, where we will use astropy 7.0. It replaces uses of `Table.pformat_all()` wih `Table.pformat()`. This silences a warning.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc5) ~/SAO/git/cheta pformat $ pytest cheta
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 174 items                                                                                                                           

cheta/tests/test_comps.py ............................................................                                                  [ 34%]
cheta/tests/test_data_source.py .........                                                                                               [ 39%]
cheta/tests/test_fetch.py ................................                                                                              [ 58%]
cheta/tests/test_intervals.py .........................                                                                                 [ 72%]
cheta/tests/test_orbit.py .                                                                                                             [ 72%]
cheta/tests/test_remote_access.py ......                                                                                                [ 76%]
cheta/tests/test_sync.py ........                                                                                                       [ 81%]
cheta/tests/test_units.py ...........                                                                                                   [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                          [ 93%]
cheta/tests/test_utils.py ...........                                                                                                   [100%]

============================================================== warnings summary ===============================================================
cheta/cheta/tests/test_comps.py::test_cmd_states
  /Users/javierg/miniforge3/envs/ska3-flight-2025.0rc5/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 174 passed, 1 warning in 93.40s (0:01:33) ==================================================

```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
