### PR TITLE
Add remote access traceback + fix MSID.iplot() + docs update

### DIFF
--- a/cheta/derived/comps.py
+++ b/cheta/derived/comps.py
@@ -7,8 +7,7 @@ Support computed MSIDs in the cheta archive.
   Cleaned MUPS valve temperatures MSIDs ``(pm2thv1t|pm1thv2t)_clean``.
 - :class:`~cheta.derived.comps.Comp_KadiCommandState`:
   Commanded states ``cmd_state_<key>_<dt>`` for any kadi commanded state value.
-- :class:`~cheta.derived.comps.Comp_Quat`:
-  Quaternions
+- :class:`~cheta.derived.comps.Comp_Quat`: Quaternions
     - ``quat_aoattqt`` = ``AOATTQT[1-4]``
     - ``quat_aoatupq`` = ``AOATUPQ[1-3]``
     - ``quat_aocmdqt`` = ``AOCMDQT[1-3]``

--- a/cheta/remote_access.py
+++ b/cheta/remote_access.py
@@ -157,7 +157,12 @@ def establish_connection():
                 client_key_file, sshserver=f"{username}@{hostname}", password=password
             )
         except Exception:
+            import traceback
+
             print("Error connecting to server ", hostname, ": ", sys.exc_info()[0])
+            print()
+            traceback.print_exc()
+            print()
             sys.stdout.flush()
             _remote_client = None
             # Clear out information so the user can try again

--- a/cheta/tests/test_remote_access.py
+++ b/cheta/tests/test_remote_access.py
@@ -5,7 +5,7 @@ remote server.
 
 Functional testing
 ------------------
-For tests that require remote access, yoou must be VPN'd to the remote network and enter
+For tests that require remote access, you must be VPN'd to the remote network and enter
 an IP address and credentials for the remote server. Normally this is the OCC VPN and
 chimchim (respectively) using the existing flight remote server. However, testing with
 the SI VPN and a server on the HEAD network is also possible.

--- a/cheta/tests/test_remote_access.py
+++ b/cheta/tests/test_remote_access.py
@@ -1,19 +1,29 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Test getting data archive path information for eng archive and possible access
-via a remote server.
+Test getting data archive path information for eng archive and possible access via a
+remote server.
 
-In addition, do manual tests below.  For tests that require remote access, one
-must be VPN'd to the OCC network and enter an IP address and credentials for
-chimchim.  In addition, the file ska_remote_access.json must be installed at the
-Ska3 root (sys.prefix).  Search email around Jan 3, 2019 for
-"ska_remote_access.json" to find a path to this file.
+Functional testing
+------------------
+For tests that require remote access, yoou must be VPN'd to the remote network and enter
+an IP address and credentials for the remote server. Normally this is the OCC VPN and
+chimchim (respectively) using the existing flight remote server. However, testing with
+the SI VPN and a server on the HEAD network is also possible.
 
-- Nominal remote access on Windows: No env vars set (SKA, ENG_ARCHIVE,
-  SKA_ACCESS_REMOTELY). Confirm that remote access is enabled and works by
-  fetching an MSID::
+Client remote access key file
+-----------------------------
+The file ``ska_remote_access.json`` must be installed at the Ska3 root (``python -c
+'import sys; print(sys.prefix)'``). This provides credentials for connecting to the
+server. See the TWiki path SpecialProject > DAWG > DAWG_TIPS_AND_TRICKS > Ska section
+for the file.
 
-    >>> import os os.environ.pop('SKA', None)
+Remote access on Windows
+------------------------
+Here there are no special environment vars set (SKA, ENG_ARCHIVE, SKA_ACCESS_REMOTELY).
+Confirm that remote access is enabled and works by fetching an MSID::
+
+    >>> import os
+    >>> os.environ.pop('SKA', None)
     >>> os.environ.pop('ENG_ARCHIVE', None)
     >>> os.environ.pop('SKA_ACCESS_REMOTELY', None)
     >>> from cheta import fetch, remote_access
@@ -22,9 +32,10 @@ Ska3 root (sys.prefix).  Search email around Jan 3, 2019 for
     >>> dat = fetch.Msid('tephin', '2018:001', '2018:010')
     >>> print(dat.vals)
 
-- Override remote access on Windows by setting SKA to a valid path so eng
-  archive data will be found. Confirm that remote access is disabled and fetch
-  uses local access::
+Local Ska data on Windows
+-------------------------
+Override remote access on Windows by setting SKA to a valid path so eng archive data is
+found. Confirm that remote access is disabled and fetch uses local access::
 
     >>> import os
     >>> os.environ['SKA'] = <path_to_ska_root>
@@ -36,8 +47,9 @@ Ska3 root (sys.prefix).  Search email around Jan 3, 2019 for
     >>> dat = fetch.Msid('1wrat', '2018:001', '2018:010')
     >>> print(dat.vals)
 
-- Override remote access on non-Windows by setting SKA_ACCESS_REMOTELY to
-  'True'::
+Remote access on non-Windows
+----------------------------
+Override remote access on non-Windows by setting SKA_ACCESS_REMOTELY to 'True'::
 
     >>> import os
     >>> os.environ['SKA_ACCESS_REMOTELY'] = 'True'
@@ -45,30 +57,41 @@ Ska3 root (sys.prefix).  Search email around Jan 3, 2019 for
     >>> import fetch, remote_access
     >>> fetch.add_logging_handler()
     >>> assert remote_access.access_remotely is True
+
+    # Optional for testing with a custom remote server on kady
+    >>> remote_access.client_key_file = <path_to_ska_remote_access.json>
+
     >>> dat = fetch.Msid('tephin', '2018:001', '2018:010')
     >>> print(dat.vals)
 
+Start a test remote server
+--------------------------
+Normally it is sufficient to use the existing ``chimchim`` server. However, for testing
+with a new Python version or other changes, you can start a new server on ``kady``.
+
 Scripts related to starting and maintaining a remote data server can be found in
-`/home/mbaski/python`. The files there are named obviously.
+``/home/mbaski/python``. The files there are named obviously, though circa 2025 they
+still refer to SHINY throughout.
 
-As an example:
-```
-/proj/sot/ska3/shiny/bin/skare /proj/sot/ska3/shiny/bin/ipcontroller --profile=test_remote \
- --reuse \
- >& remote_ipython_server.log &
+.. warning:: For aspect team testing, it is best to use ``kady`` as the test server.
+     There was some question about whether testing on ``chimchim`` was interfering
+     with the production server that is normally running.
 
-/proj/sot/ska3/shiny/bin/skare /proj/sot/ska3/shiny/bin/ipengine \
-  --file /home/taldcroft/.ipython/profile_test_remote/security/ipcontroller-engine.json \
+As an example (in the flight Ska3 environment)::
+
+  ipcontroller --profile=test_remote --reuse >& remote_ipython_server.log &
+
+  ipengine --file $HOME/.ipython/profile_test_remote/security/ipcontroller-engine.json \
   >& remote_ipython_engine.log &
-```
 
-The first time you run the `ipcontroller` command this will create the
-`ipcontroller-client.json` and `ipcontroller-engine.json` files in
-`$HOME/.ipython/profile_test_remote/security/`.
+The first time you run the ``ipcontroller`` command this will create the
+``ipcontroller-client.json`` and ``ipcontroller-engine.json`` files in
+``$HOME/.ipython/profile_test_remote/security/``. You might want to skip the ``--reuse``
+flag to get a fresh start if things are not working.
 
-The `ipcontroller-client.json` then needs to be placed into the Ska3
-installation root directory (`python -c 'import sys; print(sys.prefix)'`) as
-`ska_remote_access.json`.
+The ``ipcontroller-client.json`` then needs to be copied to the local client machine.
+For testing, you should copy it to any local file and then override
+``remote_access.client_key_file`` accordingly.
 """
 
 import os


### PR DESCRIPTION
## Description

- Add a traceback output when there is an exception in remote access initialization. 
  - Previously only the `str(exception)` was printed, which is generally not sufficient.
- Update remote access internal documentation to help in testing and diagnosing problems.
- Fix `MSID.iplot()`.
  - This has been broken for a while, but it is still a useful function.

Not passing ruff but the issues are fixed in the follow-on #269 which merges into this PR.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc2) ➜  cheta git:(remote-access-traceback) git rev-parse --short HEAD
3065bf7
(ska3-flight-2025.0rc2) ➜  cheta git:(remote-access-traceback) pytest
=============================================== test session starts ================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 174 items                                                                                                

cheta/tests/test_comps.py ............................................................                       [ 34%]
cheta/tests/test_data_source.py .........                                                                    [ 39%]
cheta/tests/test_fetch.py ................................                                                   [ 58%]
cheta/tests/test_intervals.py .........................                                                      [ 72%]
cheta/tests/test_orbit.py .                                                                                  [ 72%]
cheta/tests/test_remote_access.py ......                                                                     [ 76%]
cheta/tests/test_sync.py ........                                                                            [ 81%]
cheta/tests/test_units.py ...........                                                                        [ 87%]
cheta/tests/test_units_reversed.py ...........                                                               [ 93%]
cheta/tests/test_utils.py ...........                                                                        [100%]

========================================== 174 passed in 88.26s (0:01:28) ==========================================
```

Independent check of unit tests by Jean
- [x] OSX arm64
```
(2025.1rc1) flame:cheta jean$ pytest
============================================================================================== test session starts ==============================================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 174 items                                                                                                                                                                                             

cheta/tests/test_comps.py ............................................................                                                                                                                    [ 34%]
cheta/tests/test_data_source.py .........                                                                                                                                                                 [ 39%]
cheta/tests/test_fetch.py ................................                                                                                                                                                [ 58%]
cheta/tests/test_intervals.py .........................                                                                                                                                                   [ 72%]
cheta/tests/test_orbit.py .                                                                                                                                                                               [ 72%]
cheta/tests/test_remote_access.py ......                                                                                                                                                                  [ 76%]
cheta/tests/test_sync.py ........                                                                                                                                                                         [ 81%]
cheta/tests/test_units.py ...........                                                                                                                                                                     [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                                                                                            [ 93%]
cheta/tests/test_utils.py ...........                                                                                                                                                                     [100%]

=============================================================================================== warnings summary ================================================================================================
cheta/cheta/tests/test_comps.py::test_cmd_states
  /Users/jean/miniforge3/envs/2025.1rc1/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

cheta/cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /Users/jean/miniforge3/envs/2025.1rc1/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

cheta/cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /Users/jean/miniforge3/envs/2025.1rc1/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 174 passed, 3 warnings in 93.30s (0:01:33
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
#### `MSID.iplot()`

```
>>> from cheta import fetch
>>>dat = fetch.Msid("tephin", "2024:001", "2024:100", stat="daily")
>>> dat.iplot()
# [OK] Plot shows up.

# [OK] Focus on window and press "?". Following text is displayed:
Interactive MSID plot keys:

  a: autoscale for full data range in x and y
  m: toggle plotting of min/max values
  p: pan at cursor x
  y: toggle autoscaling of y-axis
  z: zoom at cursor x
  ?: print help

# [OK] Try each of the available options and confirm the expected behavior.
```
#### No ska_remote_access file
```
>>> import os
>>> os.environ['SKA_ACCESS_REMOTELY'] = 'True'
>>> from cheta import fetch, remote_access

>>> dat = fetch.Msid("tephin", "2024:001", "2024:100")
Enter hostname (or IP) of Ska server (enter to cancel):100.100.100.101 
Enter your login username [aldcroft]:
Enter your password:
Establishing connection to 100.100.100.101...
Error connecting to server  100.100.100.101 :  <class 'OSError'>

Traceback (most recent call last):
  File "/Volumes/git/cheta/cheta/remote_access.py", line 156, in establish_connection
    _remote_client = parallel.Client(
                     ^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/ipyparallel/client/client.py", line 471, in __init__
    raise OSError(
OSError: Connection file ~/miniconda3-arm/envs/ska3-flight-2025.0rc2/ska_remote_access.json not found. Is a controller running?
```
#### Bad host (after creating appropriate remote access file)
```
>>> dat = fetch.Msid("tephin", "2024:001", "2024:100")
Enter hostname (or IP) of Ska server (enter to cancel):100.100.100.101
Enter your login username [aldcroft]:aldcroft
Enter your password:
Establishing connection to 100.100.100.101...
Error connecting to server  100.100.100.101 :  <class 'zmq.ssh.tunnel.MaxRetryExceeded'>

Traceback (most recent call last):
  File "/Volumes/git/cheta/cheta/remote_access.py", line 156, in establish_connection
    _remote_client = parallel.Client(
                     ^^^^^^^^^^^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/ipyparallel/client/client.py", line 585, in __init__
    tunnel.tunnel_connection(
  File "/Users/aldcroft/miniconda3-arm/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/zmq/ssh/tunnel.py", line 159, in tunnel_connection
    new_url, tunnel = open_tunnel(
                      ^^^^^^^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/zmq/ssh/tunnel.py", line 194, in open_tunnel
    tunnel = tunnelf(
             ^^^^^^^^
  File "/Users/aldcroft/miniconda3-arm/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/zmq/ssh/tunnel.py", line 298, in openssh_tunnel
    raise MaxRetryExceeded(f"Failed after {MAX_RETRY} attempts")
zmq.ssh.tunnel.MaxRetryExceeded: Failed after 10 attempts
```

