### PR TITLE
Require at least one row of data in full data for server sync

### DIFF
--- a/cheta/update_server_sync.py
+++ b/cheta/update_server_sync.py
@@ -285,10 +285,13 @@ def update_index_file(index_file, opt, logger):
                 f"filetime > {DateTime(filetime0).fits[:-4]} {filetime0} "
                 f"filetime <= {DateTime(filetime1).fits[:-4]} {filetime1} "
             )
+            # Require files in time range and which have at least one row of data. It
+            # can happen that L0 files are created but with zero rows.
             archfiles = dbi.fetchall(
                 "select * from archfiles "
                 f"where filetime > {filetime0} "
                 f"and filetime <= {filetime1} "
+                "and rowstop > rowstart "
                 "order by filetime "
             )
 


### PR DESCRIPTION
## Description

After a 2-day shutdown of CXC processing, there was an exception in cheta_update_server_sync processing:
```
2025-01-30 04:42:13,408 Writing 3 row(s) to index file /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/index.ecsv
2025-01-30 04:42:13,815 Writing /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/2025-01-27T0256z/full.pkl.gz with 3948 rows of data and 36 msids
2025-01-30 04:42:14,496 Writing /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/2025-01-27T0256z/5min.pkl.gz with 396 rows of data and 32 msids
2025-01-30 04:42:15,253 Writing /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/2025-01-27T0256z/daily.pkl.gz with 4 rows of data and 32 msids
2025-01-30 04:42:15,428 Writing /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/2025-01-28T1455z/full.pkl.gz with 3923 rows of data and 36 msids
2025-01-30 04:42:15,629 Writing /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/2025-01-28T1455z/5min.pkl.gz with 391 rows of data and 32 msids
2025-01-30 04:42:16,512 Writing /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/2025-01-28T1455z/daily.pkl.gz with 0 rows of data and 32 msids
2025-01-30 04:42:16,623 Writing /proj/sot/ska3/flight/data/eng_archive/sync/sim_mrg/2025-01-30T0241z/full.pkl.gz with 0 rows of data and 36 msids
Traceback (most recent call last):
  File "/proj/sot/ska3/flight/bin/cheta_update_server_sync", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/cheta/update_server_sync.py", line 134, in main
    update_sync_repo(opt, logger, content)
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/cheta/update_server_sync.py", line 200, in update_sync_repo
    update_sync_data_stat(content, logger, row, "5min")
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/cheta/update_server_sync.py", line 499, in update_sync_data_stat
    tstart = table[row["row0"]]
             ~~~~~^^^^^^^^^^^^^
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/tables/array.py", line 624, in __getitem__
    startl, stopl, stepl, shape = self._interpret_indexing(key)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/tables/array.py", line 383, in _interpret_indexing
    raise IndexError("Index out of range")
IndexError: Index out of range
```

This error is due to CXC L0 creating a sim_mrg file with 0 rows, and then having that single archive file be the only one within a sync block (the 2025-01-30T0241z). The code was not expecting to have zero rows in a full-resolution sync file. 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux (HEAD kady) -- changed code is covered in tests
The failure of `test_cxotime_now` is because this requires updates to `chandra_time` and `cxotime` that are not installed. Since this test is entirely unrelated to this PR, the failure is acceptable.
```
ska3-kady$ git rev-parse --short HEAD
23ba4b7
ska3-kady$ pytest
======================================================================= test session starts =======================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /data/baffin/tom/git/cheta
plugins: anyio-4.3.0, timeout-2.2.0
collected 175 items                                                                                                                                               

cheta/tests/test_comps.py ............................................................                                                                      [ 34%]
cheta/tests/test_data_source.py .........                                                                                                                   [ 39%]
cheta/tests/test_fetch.py ....................F............                                                                                                 [ 58%]
cheta/tests/test_intervals.py .........................                                                                                                     [ 72%]
cheta/tests/test_orbit.py .                                                                                                                                 [ 73%]
cheta/tests/test_remote_access.py ......                                                                                                                    [ 76%]
cheta/tests/test_sync.py ........                                                                                                                           [ 81%]
cheta/tests/test_units.py ...........                                                                                                                       [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                                              [ 93%]
cheta/tests/test_utils.py ...........                                                                                                                       [100%]

FAILED cheta/tests/test_fetch.py::test_cxotime_now - AssertionError: assert '2025:030:02:33:50.816' < '2025:002:00:00:00.000'
===================================================== 1 failed, 174 passed, 336 warnings in 135.26s (0:02:15) =====================================================
```

Independent check of unit tests by Jean
- [x] OSX
```
(ska3) flame:cheta jean$ export PYTHONPATH=/Users/jean/git/chandra_time:/Users/jean/git/cxotime
(ska3) flame:cheta jean$ git rev-parse HEAD
23ba4b74c26d9682eb33ca667e85f87fb0ab47f5
(ska3) flame:cheta jean$ pytest
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 175 items                                                                                                                                        

cheta/tests/test_comps.py ............................................................                                                               [ 34%]
cheta/tests/test_data_source.py .........                                                                                                            [ 39%]
cheta/tests/test_fetch.py .................................                                                                                          [ 58%]
cheta/tests/test_intervals.py .........................                                                                                              [ 72%]
cheta/tests/test_orbit.py .                                                                                                                          [ 73%]
cheta/tests/test_remote_access.py ......                                                                                                             [ 76%]
cheta/tests/test_sync.py ........                                                                                                                    [ 81%]
cheta/tests/test_units.py ...........                                                                                                                [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                                       [ 93%]
cheta/tests/test_utils.py ...........                                                                                                                [100%]

===================================================================== warnings summary =====================================================================
cheta/cheta/tests/test_comps.py::test_cmd_states
  /Users/jean/miniforge3/envs/ska3/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

cheta/cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /Users/jean/miniforge3/envs/ska3/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

cheta/cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /Users/jean/miniforge3/envs/ska3/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 175 passed, 3 warnings in 92.71s (0:01:32
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Running this from the cheta repo on HEAD succeeds and gives the expected output:

#### Setup
```
mkdir sync
rsync /proj/sot/.snapshot/daily.2025-01-29_0010/ska/data/eng_archive/sync/msid_contents.pkl.gz sync/
rsync -av /proj/sot/.snapshot/daily.2025-01-29_0010/ska/data/eng_archive/sync/sim_mrg sync/
```
#### Running
```
ska3-kady$ python -m cheta.update_server_sync --sync-root=. --content=sim_mrg
2025-01-30 08:53:46,733 Writing 2 row(s) to index file /data/baffin/tom/git/cheta/sync/sim_mrg/index.ecsv
2025-01-30 08:53:47,142 Writing /data/baffin/tom/git/cheta/sync/sim_mrg/2025-01-27T0256z/full.pkl.gz with 3948 rows of data and 36 msids
2025-01-30 08:53:47,362 Writing /data/baffin/tom/git/cheta/sync/sim_mrg/2025-01-27T0256z/5min.pkl.gz with 396 rows of data and 32 msids
2025-01-30 08:53:47,924 Writing /data/baffin/tom/git/cheta/sync/sim_mrg/2025-01-27T0256z/daily.pkl.gz with 4 rows of data and 32 msids
2025-01-30 08:53:48,126 Writing /data/baffin/tom/git/cheta/sync/sim_mrg/2025-01-28T1455z/full.pkl.gz with 3923 rows of data and 36 msids
2025-01-30 08:53:48,338 Writing /data/baffin/tom/git/cheta/sync/sim_mrg/2025-01-28T1455z/5min.pkl.gz with 391 rows of data and 32 msids
2025-01-30 08:53:48,941 Writing /data/baffin/tom/git/cheta/sync/sim_mrg/2025-01-28T1455z/daily.pkl.gz with 0 rows of data and 32 msids
2025-01-30 08:53:48,944 Removing sync directory /data/baffin/tom/git/cheta/sync/sim_mrg/2024-11-29T1826z
2025-01-30 08:53:48,946 Removing sync directory /data/baffin/tom/git/cheta/sync/sim_mrg/2024-12-01T0213z
2025-01-30 08:53:48,949 Writing 60 row(s) to index file /data/baffin/tom/git/cheta/sync/sim_mrg/index.ecsv
2025-01-30 08:53:48,966 Writing contents pickle /data/baffin/tom/git/cheta/sync/msid_contents.pkl.gz
```
