### PR TITLE
Fix update scripts broken in #269 + unrelated docs fixes

### DIFF
--- a/cheta/check_integrity.py
+++ b/cheta/check_integrity.py
@@ -11,6 +11,7 @@ import pyyaks.logger
 import Ska.DBI
 import tables
 
+import cheta.remote_access
 from cheta import fetch
 
 opt = None
@@ -167,7 +168,9 @@ def main():
     # fetch.ENG_ARCHIVE.  Fetch is a read-only process so this is safe when
     # testing.
     if opt.data_root:
-        fetch.msid_files.basedir = ":".join([opt.data_root, fetch.ENG_ARCHIVE])
+        fetch.msid_files.basedir = ":".join(
+            [opt.data_root, cheta.remote_access.ENG_ARCHIVE]
+        )
 
     # Set up logging
     loglevel = pyyaks.logger.VERBOSE if opt.verbose else pyyaks.logger.INFO

--- a/cheta/derived/__init__.py
+++ b/cheta/derived/__init__.py
@@ -3,7 +3,7 @@
 Derived Parameters
 
 The engineering archive has pseudo-MSIDs that are derived via computation from
-telemetry MSIDs.  All derived parameter names begin with the characters "DP_"
+telemetry MSIDs.  All derived parameter names begin with the characters ``DP_``
 (not case sensitive as usual).  Otherwise there is no difference from standard
 MSIDs.
 """

--- a/cheta/get_telem.py
+++ b/cheta/get_telem.py
@@ -4,6 +4,7 @@ Fetch telemetry from the cheta archive.
 
 Examples
 ========
+::
 
   # Get full-resolution TEPHIN, AOPCADMD for 30 days, and save as telem.zip
   % ska_fetch TEPHIN AOPCADMD --start=2013:001 --stop=2013:030 --sampling=5min \\

--- a/cheta/update_archive.py
+++ b/cheta/update_archive.py
@@ -26,6 +26,7 @@ from Chandra.Time import DateTime
 from ska_helpers.retry import tables_open_file
 
 import cheta.derived
+import cheta.remote_access
 from cheta import converters, fetch, file_defs
 
 
@@ -129,11 +130,15 @@ arch_files = pyyaks.context.ContextDict(
 )
 arch_files.update(file_defs.arch_files)
 
-# Set up fetch so it will first try to read from opt.data_root if that is
-# provided as an option and exists, and if not fall back to the default of
-# fetch.ENG_ARCHIVE.  Fetch is a read-only process so this is safe when testing.
+# Set up fetch so it will first try to read from opt.data_root if that is provided as an
+# option and exists, and if not fall back to the default of
+# cheta.remote_access.ENG_ARCHIVE. In this context that could be overridden with the
+# ENG_ARCHIVE environment variable. Fetch is a read-only process so this is safe when
+# testing.
 if opt.data_root:
-    fetch.msid_files.basedir = ":".join([opt.data_root, fetch.ENG_ARCHIVE])
+    fetch.msid_files.basedir = ":".join(
+        [opt.data_root, cheta.remote_access.ENG_ARCHIVE]
+    )
 
 # Set up logging
 loglevel = pyyaks.logger.VERBOSE if opt.log_level is None else int(opt.log_level)


### PR DESCRIPTION
## Description

Somehow a critical problem slipped through in #269 and two scripts used in daily updates of the cheta archive are broken. This was found in daily masters testing. This PR fixes them.

The `fetch.ENG_ARCHIVE` symbol is still not defined, but the two scripts now refer to the original `cheta.remote_access.ENG_ARCHIVE`.

In addition, I noticed a few lingering sphinx doc build warnings and fixed them.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None (given the change in #269).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc2) ➜  cheta git:(fix-fetch-engarchive-break) git rev-parse --short HEAD
de25a1e
(ska3-flight-2025.0rc2) ➜  cheta git:(fix-fetch-engarchive-break) pytest
========================================== test session starts ===========================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: hypothesis-6.125.2, doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 175 items                                                                                      

cheta/tests/test_comps.py ............................................................             [ 34%]
cheta/tests/test_data_source.py .........                                                          [ 39%]
cheta/tests/test_fetch.py .................................                                        [ 58%]
cheta/tests/test_intervals.py .........................                                            [ 72%]
cheta/tests/test_orbit.py .                                                                        [ 73%]
cheta/tests/test_remote_access.py ......                                                           [ 76%]
cheta/tests/test_sync.py ........                                                                  [ 81%]
cheta/tests/test_units.py ...........                                                              [ 87%]
cheta/tests/test_units_reversed.py ...........                                                     [ 93%]
cheta/tests/test_utils.py ...........                                                              [100%]

===================================== 175 passed in 83.35s (0:01:23) =====================================
```
Independent check of unit tests by Jean
- [x] Linux
```
jeanconn-fido> pytest
============================================================ test session starts =============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 175 items                                                                                                                          

cheta/tests/test_comps.py ............................................................                                                 [ 34%]
cheta/tests/test_data_source.py .........                                                                                              [ 39%]
cheta/tests/test_fetch.py .................................                                                                            [ 58%]
cheta/tests/test_intervals.py .........................                                                                                [ 72%]
cheta/tests/test_orbit.py .                                                                                                            [ 73%]
cheta/tests/test_remote_access.py ......                                                                                               [ 76%]
cheta/tests/test_sync.py ........                                                                                                      [ 81%]
cheta/tests/test_units.py ...........                                                                                                  [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                         [ 93%]
cheta/tests/test_utils.py ...........                                                                                                  [100%]

============================================================== warnings summary ==============================================================
cheta/cheta/tests/test_comps.py::test_cmd_states
  /proj/sot/ska3/test/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 175 passed, 1 warning in 308.05s (0:05:08) =================================================
jeanconn-fido> python -c "import cxotime; print(cxotime.__version__)"
3.9.3.dev11+g9864220
jeanconn-fido> python -c "import chandra_time; print(chandra_time.__version__)"
4.1.3.dev8+g600c592
jeanconn-fido> git rev-parse HEAD
de25a1e2280cd0c9cb42cb9514dad1a96723265e

```


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Doing functional testing by hand is a bit labor intensive, but this will get testing in daily masters testing. I propose merging this based on unit tests and analysis and then confirm the masters test passes.
