### PR TITLE
Add back most of fetch module contents to __all__

### DIFF
--- a/cheta/fetch.py
+++ b/cheta/fetch.py
@@ -33,25 +33,62 @@ from .derived.comps import ComputedMsid
 from .lazy import LazyDict
 from .units import Units
 
+# Output of following, with a few manual edits
+#     for name in sorted(fetch.__dict__):
+#         val = fetch.__dict__[name]
+#         if inspect.ismodule(val):
+#             continue
+#         if name.startswith("_"):
+#             continue
+#         print(f"'{name}',")
 __all__ = [
-    "data_source",
-    "local_or_remote_function",
-    "get_units",
-    "set_units",
-    "read_bad_times",
-    "msid_glob",
+    "CONTENT_TIME_RANGES",
+    "ComputedMsid",
+    "DATE2000_HI",
+    "DATE2000_LO",
+    "DEFAULT_DATA_SOURCE",
+    "DIR_PATH",
+    "HrcSsMsid",
+    "IGNORE_COLNAMES",
+    "LAUNCH_DATE",
+    "LazyDict",
     "MSID",
     "MSIDset",
     "Msid",
     "Msidset",
-    "HrcSsMsid",
-    "memoized",
-    "get_time_range",
-    "get_telem",
+    "NullHandler",
+    "Path",
+    "STATE_CODES",
+    "UNITS",
+    "Units",
     "add_logging_handler",
-    "get_data_gap_spec_parser",
-    "msid_matches_data_gap_spec",
+    "all_colnames",
+    "all_msid_names_files",
+    "content",
     "create_msid_data_gap",
+    "data_source",
+    "filetype",
+    "filetypes",
+    "filetypes_arr",
+    "filetypes_tbl",
+    "get_data_gap_spec_parser",
+    "get_interval",
+    "get_telem",
+    "get_time_range",
+    "get_units",
+    "load_content",
+    "load_msid_names",
+    "local_or_remote_function",
+    "logger",
+    "lru_cache_timed",
+    "memoized",
+    "msid_bad_times",
+    "msid_files",
+    "msid_glob",
+    "msid_matches_data_gap_spec",
+    "read_bad_times",
+    "set_units",
+    "times_cache",
 ]
 
 # Module-level units, defaults to CXC units (e.g. Kelvins etc)


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes an issue where some code is relying on module attributes in `fetch_eng` that were removed in #269.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds back symbols to the public API that were removed.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc2) ➜  cheta git:(add-back-all-exports) git rev-parse --short HEAD
e0432f3
(ska3-flight-2025.0rc2) ➜  cheta git:(add-back-all-exports) pytest
================================================ test session starts =================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: hypothesis-6.125.2, doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 175 items                                                                                                  

cheta/tests/test_comps.py ............................................................                         [ 34%]
cheta/tests/test_data_source.py .........                                                                      [ 39%]
cheta/tests/test_fetch.py .................................                                                    [ 58%]
cheta/tests/test_intervals.py .........................                                                        [ 72%]
cheta/tests/test_orbit.py .                                                                                    [ 73%]
cheta/tests/test_remote_access.py ......                                                                       [ 76%]
cheta/tests/test_sync.py ........                                                                              [ 81%]
cheta/tests/test_units.py ...........                                                                          [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                 [ 93%]
cheta/tests/test_utils.py ...........                                                                          [100%]

========================================== 175 passed in 193.33s (0:03:13) ===========================================
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
