### PR TITLE
Update repr to handle objects without dtype like Quat

### DIFF
--- a/cheta/fetch.py
+++ b/cheta/fetch.py
@@ -538,11 +538,16 @@ class MSID(object):
 
     def __repr__(self):
         attrs = [self.__class__.__name__, self.MSID]
+        # Try to get dtype name, but handle objects without .dtype
+        try:
+            dtype_name = self.dtype.name
+        except Exception:
+            dtype_name = type(self.vals).__name__
         for name, val in (
             ("start", self.datestart),
             ("stop", self.datestop),
             ("len", len(self)),
-            ("dtype", self.dtype.name),
+            ("dtype", dtype_name),
             ("unit", self.unit),
             ("stat", self.stat),
         ):

--- a/cheta/fetch.py
+++ b/cheta/fetch.py
@@ -538,7 +538,7 @@ class MSID(object):
 
     def __repr__(self):
         attrs = [self.__class__.__name__, self.MSID]
-        # Try to get dtype name, but handle objects without .dtype
+        # Try to get dtype name, but handle objects without .dtype like Quat
         try:
             dtype_name = self.dtype.name
         except Exception:


### PR DESCRIPTION
## Description

Update repr to handle objects without dtype like Quat

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #262 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:cheta jean$ git rev-parse HEAD
e7c7d666f61c21351bb3dc32ed8adc062aafcbca
(ska3-latest) flame:cheta jean$ pytest
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: socket-0.7.0, anyio-4.7.0, timeout-2.3.1
collected 175 items                                                                                                                                        

cheta/tests/test_comps.py ............................................................                                                               [ 34%]
cheta/tests/test_data_source.py .........                                                                                                            [ 39%]
cheta/tests/test_fetch.py .................................                                                                                          [ 58%]
cheta/tests/test_intervals.py .........................                                                                                              [ 72%]
cheta/tests/test_orbit.py .                                                                                                                          [ 73%]
cheta/tests/test_remote_access.py ......                                                                                                             [ 76%]
cheta/tests/test_sync.py ........                                                                                                                    [ 81%]
cheta/tests/test_units.py ...........                                                                                                                [ 87%]
cheta/tests/test_units_reversed.py ...........                                                                                                       [ 93%]
cheta/tests/test_utils.py ...........                                                                                                                [100%]

===================================================================== warnings summary =====================================================================
cheta/cheta/tests/test_comps.py::test_cmd_states
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/setuptools_scm/git.py:312: UserWarning: git archive did not support describe output
    warnings.warn("git archive did not support describe output")

cheta/cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

cheta/cheta/tests/test_intervals.py::test_fetch_MSID_intervals
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 175 passed, 3 warnings in 133.81s (0:02:13)
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
In [1]: from cheta import fetch

In [2]: fetch.Msid('quat_aoattqt', '2024:001', '2024:002')
Out[2]: <Msid QUAT_AOATTQT start=2024:001:00:00:00.000 stop=2024:002:00:00:00.000 len=84293 dtype=Quat>
```
instead of the output seen in #262 